### PR TITLE
Returns same size matrix as input times

### DIFF
--- a/+plx/convertTimeToSamples.m
+++ b/+plx/convertTimeToSamples.m
@@ -2,7 +2,7 @@ function samples = convertTimeToSamples(times, adfreq, ts, fn)
 % Convert timestamps into samples using sampling rate and start-time
 % samples = convertTimeToSamples(times, adfreq, ts, fn)
 % inputs:
-%   times  [n x 1] - vector of timestamps
+%   times  [any] - vector/matrix of timestamps
 %  adfreq  [1 x 1] - sampling rate
 %      ts  [m x 1] - vector of recording fragment start timestamps
 %      fn  [m x 1] - vector of fragment sample counts
@@ -27,7 +27,7 @@ nfragments = numel(fn);
 fb = ts;
 fe = (ts+fn*adfreq);
 
-samples = nan(numel(times),1);
+samples = nan(size(times));
 for ff = 1:nfragments
     idx = times >= fb(ff) & times <= fe(ff);
     samples(idx) = floor((times(idx) - fb(ff))*adfreq)+1;


### PR DESCRIPTION
Before: it returned a vector, even if the input was a matrix. Required reshaping.
After: now it returns the same size as the input! Much more convenient.
